### PR TITLE
Fix issue with strand_specific code

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ matplotlib
 seaborn
 multiprocessing
 pybedtools
-parmap
+parmap==1.5.1
 pysam
 pandas>=0.16
 numpy

--- a/src/analysis.py
+++ b/src/analysis.py
@@ -426,7 +426,7 @@ class Analysis(object):
                         count_reads_in_intervals,
                         [sample.filtered for sample in samples],
                         sites_str,
-                        parallel=True
+                        pm_parallel=True
                     )
             ),
             index=[sample.name for sample in samples]
@@ -3417,7 +3417,7 @@ def characterize_regions_chromatin(analysis, traits, extend=False):
                         count_reads_in_intervals,
                         [sample.filtered for sample in samples],
                         sites_str,
-                        parallel=True
+                        pm_parallel=True
                     )
             ),
             index=[sample.name for sample in samples]

--- a/src/footprints.py
+++ b/src/footprints.py
@@ -176,7 +176,7 @@ def get_reads_in_intervals(bam, intervals, strand_specific=False):
         intervals.values(),
         bam,
         strand_specific=strand_specific,
-        parallel=True)
+        pm_parallel=True)
 
     if not strand_specific:
         coverage = np.vstack(coverage)


### PR DESCRIPTION
Hi,

As the parmap author I have been contacting parmap users to make sure they can smoothly update to the minor API changes I had to make in `parmap==1.5.0`. This pull request updates your code to reflect those changes. Basically I had to replace `parallel=True` with `pm_parallel=True`. It has been so far a very smooth upgrade with no issues in any other parmap user.

Unfortunately, I have found an issue in your usage of parmap that may have lead to some incorrect results. Until parmap 1.5.0, `parmap.map` supported multiple *positional* arguments, but not *keyword* arguments. This was stated in the [README](https://github.com/zeehio/parmap/blob/e597fb4df1cecac5eca17fbb4b3ec509d5d84138/README.rst#what-does-parmap-offer). However, you were using `parmap` and trying to pass the `strand_specific=` keyword argument in this [line of code](https://github.com/epigen/cll-chromatin/blob/master/src/footprints.py#L178). I am sorry to say that this keyword argument was never passed to the underlying `coverage_single` function, and therefore the default `strand_specific=False` was always used.

If you want to check the impact of this bug on your results, please make sure you have the latest parmap version installed (which *does* support keyword arguments, you can use `pip install -U parmap`) and run your code again, once you have accepted this pull request. I hope for the best and that the impact is small.

Best,

Sergio